### PR TITLE
fix format

### DIFF
--- a/api/users/controller/user-controller.go
+++ b/api/users/controller/user-controller.go
@@ -119,7 +119,7 @@ func RegisterForEvent(c *fiber.Ctx) error {
 		return nil
 	}
 	user.ID = primitive.NewObjectID()
-	user.CreatedAt = time.Now().Unix()
+	user.CreatedAt = fmt.Sprintf("%v",time.Now().Unix())
 	user.EventSlugs = append(user.EventSlugs, reqBody.EventSlug)
 	res, err := usersCollection.InsertOne(context.Background(), user)
 	if err != nil {


### PR DESCRIPTION
Fix format
convert time.Now().Unix() type int to type string